### PR TITLE
Collin/improved account type

### DIFF
--- a/ocular/src/account.rs
+++ b/ocular/src/account.rs
@@ -1,12 +1,64 @@
+use std::sync::Arc;
+
 use cosmrs::{crypto::secp256k1::SigningKey, crypto::PublicKey, AccountId};
 
 use crate::error::AccountError;
 
-///  Type to hold all information around an account.
+/// Represents a local account derived from a [`SigningKey`].
+///
+/// Note: Attempting a transaction with an account made from a newly generated key will fail as the account does not actually exist
+/// on-chain yet.
+#[derive(Clone)]
 pub struct AccountInfo {
-    pub id: AccountId,
-    pub public_key: PublicKey,
-    pub private_key: SigningKey,
+    public_key: PublicKey,
+    private_key: Arc<SigningKey>,
+}
+
+impl AccountInfo {
+    pub fn address(&self, prefix: &str) -> String {
+        self.id(prefix).as_ref().to_string()
+    }
+
+    pub fn id(&self, prefix: &str) -> AccountId {
+        self.public_key
+            .account_id(prefix)
+            .expect("failed to derive account id from public key. if this panic ever occurs there is a bug with AccountInfo construction.")
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        self.public_key
+    }
+
+    pub fn private_key(&self) -> &SigningKey {
+        self.private_key.as_ref()
+    }
+}
+
+impl TryFrom<SigningKey> for AccountInfo {
+    type Error = AccountError;
+
+    fn try_from(value: SigningKey) -> Result<Self, Self::Error> {
+        Self::try_from(Arc::new(value))
+    }
+}
+
+impl TryFrom<Arc<SigningKey>> for AccountInfo {
+    type Error = AccountError;
+
+    fn try_from(value: Arc<SigningKey>) -> Result<Self, Self::Error> {
+        let private_key = value;
+        let public_key = private_key.public_key();
+
+        // By doing this check here, we can assert that self.id() and self.address() will not error (so long as all constructors make this check)
+        if let Err(_) = public_key.account_id("testprefix") {
+            return Err(AccountError::InvalidPublicKey("unable to derive AccountId from key".to_string()))
+        }
+
+        Ok(AccountInfo {
+            private_key,
+            public_key,
+        })
+    }
 }
 
 /// Used for converting the BaseAccount type in cosmos_sdk_proto to something with concrete field types

--- a/ocular/src/account.rs
+++ b/ocular/src/account.rs
@@ -50,7 +50,7 @@ impl TryFrom<Arc<SigningKey>> for AccountInfo {
         let public_key = private_key.public_key();
 
         // By doing this check here, we can assert that self.id() and self.address() will not error (so long as all constructors make this check)
-        if let Err(_) = public_key.account_id("testprefix") {
+        if public_key.account_id("testprefix").is_err() {
             return Err(AccountError::InvalidPublicKey(
                 "unable to derive AccountId from key".to_string(),
             ));

--- a/ocular/src/account.rs
+++ b/ocular/src/account.rs
@@ -51,7 +51,9 @@ impl TryFrom<Arc<SigningKey>> for AccountInfo {
 
         // By doing this check here, we can assert that self.id() and self.address() will not error (so long as all constructors make this check)
         if let Err(_) = public_key.account_id("testprefix") {
-            return Err(AccountError::InvalidPublicKey("unable to derive AccountId from key".to_string()))
+            return Err(AccountError::InvalidPublicKey(
+                "unable to derive AccountId from key".to_string(),
+            ));
         }
 
         Ok(AccountInfo {

--- a/ocular/src/chain/client/airdrop.rs
+++ b/ocular/src/chain/client/airdrop.rs
@@ -91,11 +91,11 @@ impl ChainClient {
         payments: Vec<Payment>,
         tx_metadata: Option<TxMetadata>,
     ) -> Result<Response, ChainClientError> {
-        self.verify_multi_send_grant(granter.id.clone(), grantee.id.clone())
+        self.verify_multi_send_grant(granter.id(&self.config.account_prefix), grantee.id(&self.config.account_prefix))
             .await?;
 
         let (inputs, outputs) =
-            multi_send_args_from_payments(granter.id.as_ref().to_string(), payments);
+            multi_send_args_from_payments(granter.address(&self.config.account_prefix), payments);
         let msgs: Vec<prost_types::Any> = vec![MsgMultiSend {
             inputs: inputs
                 .iter()
@@ -118,7 +118,7 @@ impl ChainClient {
     ) -> Result<Response, ChainClientError> {
         let payments_toml = read_payments_toml(path)?;
         let grantee = match payments_toml.grantee_key_name {
-            Some(g) => self.keyring.get_account(&g, &self.config.account_prefix),
+            Some(g) => self.keyring.get_account(&g),
             None => {
                 return Err(AirdropError::Toml(
                     "no grantee key name was provided for the delegated airdrop.".to_string(),
@@ -128,7 +128,7 @@ impl ChainClient {
         }?;
         let granter = self
             .keyring
-            .get_account(&payments_toml.sender_key_name, &self.config.account_prefix)?;
+            .get_account(&payments_toml.sender_key_name)?;
 
         // add fee_payer and fee_granter values to metadata if present
         let basic_tx_metadata = self.get_basic_tx_metadata().await?;
@@ -161,7 +161,7 @@ impl ChainClient {
         tx_metadata: Option<TxMetadata>,
     ) -> Result<Response, ChainClientError> {
         let (inputs, outputs) =
-            multi_send_args_from_payments(sender.id.as_ref().to_string(), payments);
+            multi_send_args_from_payments(sender.address(&self.config.account_prefix), payments);
         self.multi_send(sender, inputs, outputs, tx_metadata).await
     }
 
@@ -173,7 +173,7 @@ impl ChainClient {
         let payments_toml = read_payments_toml(path)?;
         let sender = self
             .keyring
-            .get_account(&payments_toml.sender_key_name, &self.config.account_prefix)?;
+            .get_account(&payments_toml.sender_key_name)?;
         self.execute_airdrop(sender, payments_toml.payments, tx_metadata)
             .await
     }

--- a/ocular/src/chain/client/airdrop.rs
+++ b/ocular/src/chain/client/airdrop.rs
@@ -92,13 +92,13 @@ impl ChainClient {
         tx_metadata: Option<TxMetadata>,
     ) -> Result<Response, ChainClientError> {
         self.verify_multi_send_grant(
-            granter.id(&self.config.account_prefix),
-            grantee.id(&self.config.account_prefix),
+            granter.id(&self.config.account_prefix)?,
+            grantee.id(&self.config.account_prefix)?,
         )
         .await?;
 
         let (inputs, outputs) =
-            multi_send_args_from_payments(granter.address(&self.config.account_prefix), payments);
+            multi_send_args_from_payments(granter.address(&self.config.account_prefix)?, payments);
         let msgs: Vec<prost_types::Any> = vec![MsgMultiSend {
             inputs: inputs
                 .iter()
@@ -162,7 +162,7 @@ impl ChainClient {
         tx_metadata: Option<TxMetadata>,
     ) -> Result<Response, ChainClientError> {
         let (inputs, outputs) =
-            multi_send_args_from_payments(sender.address(&self.config.account_prefix), payments);
+            multi_send_args_from_payments(sender.address(&self.config.account_prefix)?, payments);
         self.multi_send(sender, inputs, outputs, tx_metadata).await
     }
 

--- a/ocular/src/chain/client/airdrop.rs
+++ b/ocular/src/chain/client/airdrop.rs
@@ -91,8 +91,11 @@ impl ChainClient {
         payments: Vec<Payment>,
         tx_metadata: Option<TxMetadata>,
     ) -> Result<Response, ChainClientError> {
-        self.verify_multi_send_grant(granter.id(&self.config.account_prefix), grantee.id(&self.config.account_prefix))
-            .await?;
+        self.verify_multi_send_grant(
+            granter.id(&self.config.account_prefix),
+            grantee.id(&self.config.account_prefix),
+        )
+        .await?;
 
         let (inputs, outputs) =
             multi_send_args_from_payments(granter.address(&self.config.account_prefix), payments);
@@ -126,9 +129,7 @@ impl ChainClient {
                 .into())
             }
         }?;
-        let granter = self
-            .keyring
-            .get_account(&payments_toml.sender_key_name)?;
+        let granter = self.keyring.get_account(&payments_toml.sender_key_name)?;
 
         // add fee_payer and fee_granter values to metadata if present
         let basic_tx_metadata = self.get_basic_tx_metadata().await?;
@@ -171,9 +172,7 @@ impl ChainClient {
         tx_metadata: Option<TxMetadata>,
     ) -> Result<Response, ChainClientError> {
         let payments_toml = read_payments_toml(path)?;
-        let sender = self
-            .keyring
-            .get_account(&payments_toml.sender_key_name)?;
+        let sender = self.keyring.get_account(&payments_toml.sender_key_name)?;
         self.execute_airdrop(sender, payments_toml.payments, tx_metadata)
             .await
     }

--- a/ocular/src/chain/client/authz.rs
+++ b/ocular/src/chain/client/authz.rs
@@ -55,8 +55,7 @@ impl ChainClient {
                 break;
             } else if result.is_err() && self.cache.is_some() {
                 // Don't bother updating config grpc address if it fails, it'll be overriden upon a successful connection
-                self
-                    .cache
+                self.cache
                     .as_mut()
                     .unwrap()
                     .grpc_endpoint_cache
@@ -103,7 +102,7 @@ impl ChainClient {
         tx_metadata: TxMetadata,
     ) -> Result<Response, ChainClientError> {
         let msg = MsgGrant {
-            granter: granter.address(&self.config.account_prefix),
+            granter: granter.address(&self.config.account_prefix)?,
             grantee: grantee.to_string(),
             grant: Some(Grant {
                 authorization: Some(prost_types::Any {
@@ -134,7 +133,7 @@ impl ChainClient {
         tx_metadata: TxMetadata,
     ) -> Result<Response, ChainClientError> {
         let msg = MsgRevoke {
-            granter: granter.address(&self.config.account_prefix),
+            granter: granter.address(&self.config.account_prefix)?,
             grantee: grantee.to_string(),
             msg_type_url: String::from("/cosmos.bank.v1beta1.MsgSend"),
         };
@@ -155,7 +154,7 @@ impl ChainClient {
         tx_metadata: Option<TxMetadata>,
     ) -> Result<Response, ChainClientError> {
         let msg = MsgExec {
-            grantee: grantee.address(&self.config.account_prefix),
+            grantee: grantee.address(&self.config.account_prefix)?,
             msgs,
         };
         let msg_any = prost_types::Any {
@@ -186,7 +185,7 @@ impl ChainClient {
             expiration,
         };
         let msg = MsgGrantAllowance {
-            granter: granter.address(&self.config.account_prefix),
+            granter: granter.address(&self.config.account_prefix)?,
             grantee: grantee.to_string(),
             allowance: Some(prost_types::Any {
                 type_url: String::from("/cosmos.feegrant.v1beta1.BasicAllowance"),

--- a/ocular/src/chain/client/authz.rs
+++ b/ocular/src/chain/client/authz.rs
@@ -103,7 +103,7 @@ impl ChainClient {
         tx_metadata: TxMetadata,
     ) -> Result<Response, ChainClientError> {
         let msg = MsgGrant {
-            granter: granter.id.to_string(),
+            granter: granter.address(&self.config.account_prefix),
             grantee: grantee.to_string(),
             grant: Some(Grant {
                 authorization: Some(prost_types::Any {
@@ -134,7 +134,7 @@ impl ChainClient {
         tx_metadata: TxMetadata,
     ) -> Result<Response, ChainClientError> {
         let msg = MsgRevoke {
-            granter: granter.id.to_string(),
+            granter: granter.address(&self.config.account_prefix),
             grantee: grantee.to_string(),
             msg_type_url: String::from("/cosmos.bank.v1beta1.MsgSend"),
         };
@@ -155,7 +155,7 @@ impl ChainClient {
         tx_metadata: Option<TxMetadata>,
     ) -> Result<Response, ChainClientError> {
         let msg = MsgExec {
-            grantee: grantee.id.to_string(),
+            grantee: grantee.address(&self.config.account_prefix),
             msgs,
         };
         let msg_any = prost_types::Any {
@@ -186,7 +186,7 @@ impl ChainClient {
             expiration,
         };
         let msg = MsgGrantAllowance {
-            granter: granter.id.to_string(),
+            granter: granter.address(&self.config.account_prefix),
             grantee: grantee.to_string(),
             allowance: Some(prost_types::Any {
                 type_url: String::from("/cosmos.feegrant.v1beta1.BasicAllowance"),

--- a/ocular/src/chain/client/authz.rs
+++ b/ocular/src/chain/client/authz.rs
@@ -55,7 +55,7 @@ impl ChainClient {
                 break;
             } else if result.is_err() && self.cache.is_some() {
                 // Don't bother updating config grpc address if it fails, it'll be overriden upon a successful connection
-                let _res = self
+                self
                     .cache
                     .as_mut()
                     .unwrap()

--- a/ocular/src/chain/client/grpc.rs
+++ b/ocular/src/chain/client/grpc.rs
@@ -75,7 +75,7 @@ impl ChainClient {
                 .get_connsecutive_failed_connections_threshold();
 
             for endpt in &endpoints {
-                let _res = self
+                self
                     .cache
                     .as_mut()
                     .expect("Error accessing cache.")

--- a/ocular/src/chain/client/grpc.rs
+++ b/ocular/src/chain/client/grpc.rs
@@ -75,8 +75,7 @@ impl ChainClient {
                 .get_connsecutive_failed_connections_threshold();
 
             for endpt in &endpoints {
-                self
-                    .cache
+                self.cache
                     .as_mut()
                     .expect("Error accessing cache.")
                     .grpc_endpoint_cache

--- a/ocular/src/chain/client/query.rs
+++ b/ocular/src/chain/client/query.rs
@@ -58,8 +58,7 @@ impl ChainClient {
                 break;
             } else if result.is_err() && self.cache.is_some() {
                 // Don't bother updating config grpc address if it fails, it'll be overriden upon a successful connection
-                self
-                    .cache
+                self.cache
                     .as_mut()
                     .unwrap()
                     .grpc_endpoint_cache
@@ -142,8 +141,7 @@ impl ChainClient {
                 break;
             } else if result.is_err() && self.cache.is_some() {
                 // Don't bother updating config grpc address if it fails, it'll be overriden upon a successful connection
-                self
-                    .cache
+                self.cache
                     .as_mut()
                     .unwrap()
                     .grpc_endpoint_cache

--- a/ocular/src/chain/client/query.rs
+++ b/ocular/src/chain/client/query.rs
@@ -58,7 +58,7 @@ impl ChainClient {
                 break;
             } else if result.is_err() && self.cache.is_some() {
                 // Don't bother updating config grpc address if it fails, it'll be overriden upon a successful connection
-                let _res = self
+                self
                     .cache
                     .as_mut()
                     .unwrap()
@@ -142,7 +142,7 @@ impl ChainClient {
                 break;
             } else if result.is_err() && self.cache.is_some() {
                 // Don't bother updating config grpc address if it fails, it'll be overriden upon a successful connection
-                let _res = self
+                self
                     .cache
                     .as_mut()
                     .unwrap()

--- a/ocular/src/chain/client/tx.rs
+++ b/ocular/src/chain/client/tx.rs
@@ -162,7 +162,7 @@ impl ChainClient {
         }
 
         let msg = MsgSend {
-            from_address: sender.id(&self.config.account_prefix).clone(),
+            from_address: sender.id(&self.config.account_prefix),
             to_address: recipient,
             amount: vec![amount.clone()],
         };

--- a/ocular/src/chain/client/tx.rs
+++ b/ocular/src/chain/client/tx.rs
@@ -43,10 +43,10 @@ impl ChainClient {
         tx_body: tx::Body,
         tx_metadata: TxMetadata,
     ) -> Result<Response, ChainClientError> {
-        let account = self.query_account(sender.id.as_ref().to_string()).await?;
+        let account = self.query_account(sender.address(&self.config.account_prefix)).await?;
 
         // Create signer info.
-        let signer_info = SignerInfo::single_direct(Some(sender.public_key), account.sequence);
+        let signer_info = SignerInfo::single_direct(Some(sender.public_key()), account.sequence);
 
         // Compute auth info from signer info by associating a fee.
         let auth_info = signer_info.auth_info(Fee {
@@ -64,7 +64,7 @@ impl ChainClient {
         };
 
         // Create raw signed transaction.
-        let tx_signed = match sign_doc.sign(&sender.private_key) {
+        let tx_signed = match sign_doc.sign(sender.private_key()) {
             Ok(raw) => raw,
             Err(err) => return Err(TxError::Signing(err.to_string()).into()),
         };
@@ -160,7 +160,7 @@ impl ChainClient {
         }
 
         let msg = MsgSend {
-            from_address: sender.id.clone(),
+            from_address: sender.id(&self.config.account_prefix).clone(),
             to_address: recipient,
             amount: vec![amount.clone()],
         };

--- a/ocular/src/chain/client/tx.rs
+++ b/ocular/src/chain/client/tx.rs
@@ -43,7 +43,9 @@ impl ChainClient {
         tx_body: tx::Body,
         tx_metadata: TxMetadata,
     ) -> Result<Response, ChainClientError> {
-        let account = self.query_account(sender.address(&self.config.account_prefix)).await?;
+        let account = self
+            .query_account(sender.address(&self.config.account_prefix))
+            .await?;
 
         // Create signer info.
         let signer_info = SignerInfo::single_direct(Some(sender.public_key()), account.sequence);

--- a/ocular/src/chain/client/tx.rs
+++ b/ocular/src/chain/client/tx.rs
@@ -44,7 +44,7 @@ impl ChainClient {
         tx_metadata: TxMetadata,
     ) -> Result<Response, ChainClientError> {
         let account = self
-            .query_account(sender.address(&self.config.account_prefix))
+            .query_account(sender.address(&self.config.account_prefix)?)
             .await?;
 
         // Create signer info.
@@ -162,7 +162,7 @@ impl ChainClient {
         }
 
         let msg = MsgSend {
-            from_address: sender.id(&self.config.account_prefix),
+            from_address: sender.id(&self.config.account_prefix)?,
             to_address: recipient,
             amount: vec![amount.clone()],
         };

--- a/ocular/src/chain/client/tx/bank.rs
+++ b/ocular/src/chain/client/tx/bank.rs
@@ -46,7 +46,7 @@ impl ChainClient {
         }
 
         let msg = MsgSend {
-            from_address: sender.id(&self.config.account_prefix)?.clone(),
+            from_address: sender.id(&self.config.account_prefix)?,
             to_address: recipient,
             amount: vec![amount.clone()],
         };

--- a/ocular/src/error.rs
+++ b/ocular/src/error.rs
@@ -104,6 +104,10 @@ pub enum KeyStoreError {
     UnableToRetrieveKey(String),
     #[error("error reading file: {0}")]
     FileIO(String),
+    #[error("error deriving AccountId from PublicKey")]
+    DerivingAccountId(#[from] ErrorReport),
+    #[error("error during account retrieval")]
+    RetrievingAccount(#[from] AccountError)
 }
 
 #[derive(Debug, Error)]
@@ -165,4 +169,6 @@ pub enum AccountError {
     Empty(String),
     #[error("error decoding account data: {0}")]
     Decode(#[from] ErrorReport),
+    #[error("invalid key type")]
+    InvalidPublicKey(String)
 }

--- a/ocular/src/error.rs
+++ b/ocular/src/error.rs
@@ -107,7 +107,7 @@ pub enum KeyStoreError {
     #[error("error deriving AccountId from PublicKey")]
     DerivingAccountId(#[from] ErrorReport),
     #[error("error during account retrieval")]
-    RetrievingAccount(#[from] AccountError)
+    RetrievingAccount(#[from] AccountError),
 }
 
 #[derive(Debug, Error)]
@@ -170,5 +170,5 @@ pub enum AccountError {
     #[error("error decoding account data: {0}")]
     Decode(#[from] ErrorReport),
     #[error("invalid key type")]
-    InvalidPublicKey(String)
+    InvalidPublicKey(String),
 }

--- a/ocular/src/keyring.rs
+++ b/ocular/src/keyring.rs
@@ -240,7 +240,7 @@ impl Keyring {
 
         let private_key = self.get_key(key_name)?;
 
-        Ok(AccountInfo::try_from(private_key)?)
+        Ok(AccountInfo::from(private_key))
     }
 
     /// List all keys.
@@ -771,8 +771,8 @@ mod tests {
         // Verify recovered key is equal to deleted one
         let new_account = keyring.get_account("new_celery").unwrap();
         assert_eq!(
-            new_account.id("cosmos").as_ref(),
-            account.id("cosmos").as_ref()
+            new_account.id("cosmos").unwrap().as_ref(),
+            account.id("cosmos").unwrap().as_ref()
         );
         assert_eq!(new_account.public_key(), account.public_key());
 
@@ -873,8 +873,8 @@ mod tests {
         // Verify recovered key is equal to deleted one
         let new_account = keyring.get_account("new_trex").unwrap();
         assert_eq!(
-            new_account.id("cosmos").as_ref(),
-            account.id("cosmos").as_ref()
+            new_account.id("cosmos").unwrap().as_ref(),
+            account.id("cosmos").unwrap().as_ref()
         );
         assert_eq!(new_account.public_key(), account.public_key());
 

--- a/ocular/src/keyring.rs
+++ b/ocular/src/keyring.rs
@@ -770,7 +770,10 @@ mod tests {
 
         // Verify recovered key is equal to deleted one
         let new_account = keyring.get_account("new_celery").unwrap();
-        assert_eq!(new_account.id("cosmos").as_ref(), account.id("cosmos").as_ref());
+        assert_eq!(
+            new_account.id("cosmos").as_ref(),
+            account.id("cosmos").as_ref()
+        );
         assert_eq!(new_account.public_key(), account.public_key());
 
         // Clean up dir
@@ -869,7 +872,10 @@ mod tests {
 
         // Verify recovered key is equal to deleted one
         let new_account = keyring.get_account("new_trex").unwrap();
-        assert_eq!(new_account.id("cosmos").as_ref(), account.id("cosmos").as_ref());
+        assert_eq!(
+            new_account.id("cosmos").as_ref(),
+            account.id("cosmos").as_ref()
+        );
         assert_eq!(new_account.public_key(), account.public_key());
 
         // Clean up dir

--- a/ocular/tests/single_node_chain_txs.rs
+++ b/ocular/tests/single_node_chain_txs.rs
@@ -69,7 +69,7 @@ fn local_single_node_chain_test() {
         &format!("{}:{}", 9090, 9090),
         DOCKER_HUB_GAIA_SINGLE_NODE_TEST_IMAGE,
         CHAIN_ID,
-        &sender_account.address(ACCOUNT_PREFIX),
+        &sender_account.address(ACCOUNT_PREFIX).unwrap(),
     ];
 
     dev::docker_run(&docker_args, || {
@@ -105,8 +105,8 @@ fn local_single_node_chain_test() {
 
             // Expected MsgSend
             let msg_send = MsgSend {
-                from_address: sender_account.id(ACCOUNT_PREFIX),
-                to_address: recipient_account.id(ACCOUNT_PREFIX),
+                from_address: sender_account.id(ACCOUNT_PREFIX).unwrap(),
+                to_address: recipient_account.id(ACCOUNT_PREFIX).unwrap(),
                 amount: vec![amount.clone()],
             }
             .to_any()
@@ -128,8 +128,8 @@ fn local_single_node_chain_test() {
 
             // Expected MsgGrant
             let msg_grant = MsgGrant {
-                granter: sender_account.address(ACCOUNT_PREFIX),
-                grantee: recipient_account.address(ACCOUNT_PREFIX),
+                granter: sender_account.address(ACCOUNT_PREFIX).unwrap(),
+                grantee: recipient_account.address(ACCOUNT_PREFIX).unwrap(),
                 grant: Some(authz::Grant {
                     authorization: Some(prost_types::Any {
                         type_url: String::from("/cosmos.authz.v1beta1.GenericAuthorization"),
@@ -165,8 +165,8 @@ fn local_single_node_chain_test() {
 
             // Expected MsgRevoke
             let msg_revoke = MsgRevoke {
-                granter: sender_account.address(ACCOUNT_PREFIX),
-                grantee: recipient_account.address(ACCOUNT_PREFIX),
+                granter: sender_account.address(ACCOUNT_PREFIX).unwrap(),
+                grantee: recipient_account.address(ACCOUNT_PREFIX).unwrap(),
                 msg_type_url: String::from("/cosmos.bank.v1beta1.MsgSend"),
             };
 
@@ -192,8 +192,8 @@ fn local_single_node_chain_test() {
             let mut msgs_to_execute: Vec<::prost_types::Any> = Vec::new();
             msgs_to_execute.push(
                 MsgSend {
-                    from_address: sender_account.id(ACCOUNT_PREFIX),
-                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX),
+                    from_address: sender_account.id(ACCOUNT_PREFIX).unwrap(),
+                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX).unwrap(),
                     amount: vec![amount.clone()],
                 }
                 .to_any()
@@ -201,7 +201,7 @@ fn local_single_node_chain_test() {
             );
 
             let msg_exec = MsgExec {
-                grantee: recipient_account.address(ACCOUNT_PREFIX),
+                grantee: recipient_account.address(ACCOUNT_PREFIX).unwrap(),
                 msgs: msgs_to_execute,
             };
 
@@ -225,28 +225,28 @@ fn local_single_node_chain_test() {
 
             // expected MsgMultiSend
             let input_a = MultiSendIo {
-                address: sender_account.address(ACCOUNT_PREFIX),
+                address: sender_account.address(ACCOUNT_PREFIX).unwrap(),
                 coins: vec![ocular::tx::Coin {
                     amount: 50,
                     denom: DENOM.to_string(),
                 }],
             };
             let input_b = MultiSendIo {
-                address: sender_account.address(ACCOUNT_PREFIX),
+                address: sender_account.address(ACCOUNT_PREFIX).unwrap(),
                 coins: vec![ocular::tx::Coin {
                     amount: 100,
                     denom: DENOM.to_string(),
                 }],
             };
             let output_a = MultiSendIo {
-                address: ad_hoc_account.address(ACCOUNT_PREFIX),
+                address: ad_hoc_account.address(ACCOUNT_PREFIX).unwrap(),
                 coins: vec![ocular::tx::Coin {
                     amount: 75,
                     denom: DENOM.to_string(),
                 }],
             };
             let output_b = MultiSendIo {
-                address: recipient_account.address(ACCOUNT_PREFIX),
+                address: recipient_account.address(ACCOUNT_PREFIX).unwrap(),
                 coins: vec![ocular::tx::Coin {
                     amount: 75,
                     denom: DENOM.to_string(),
@@ -319,7 +319,7 @@ fn local_single_node_chain_test() {
             let actual_tx_commit_response = chain_client
                 .send(
                     sender_account.clone(),
-                    recipient_account.id(ACCOUNT_PREFIX).as_ref(),
+                    recipient_account.id(ACCOUNT_PREFIX).unwrap().as_ref(),
                     amount.clone(),
                     Some(tx_metadata.clone()),
                 )
@@ -341,7 +341,7 @@ fn local_single_node_chain_test() {
             let actual_msg_grant_commit_response = chain_client
                 .grant_send_authorization(
                     sender_account.clone(),
-                    recipient_account.id(ACCOUNT_PREFIX),
+                    recipient_account.id(ACCOUNT_PREFIX).unwrap(),
                     Some(prost_types::Timestamp {
                         seconds: 4110314268,
                         nanos: 0,
@@ -376,8 +376,8 @@ fn local_single_node_chain_test() {
             let mut msgs_to_send: Vec<::prost_types::Any> = Vec::new();
             msgs_to_send.push(
                 MsgSend {
-                    from_address: sender_account.id(ACCOUNT_PREFIX),
-                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX),
+                    from_address: sender_account.id(ACCOUNT_PREFIX).unwrap(),
+                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX).unwrap(),
                     amount: vec![amount.clone()],
                 }
                 .to_any()
@@ -417,7 +417,7 @@ fn local_single_node_chain_test() {
             let actual_msg_revoke_commit_response = chain_client
                 .revoke_send_authorization(
                     sender_account.clone(),
-                    grantee_account.id(ACCOUNT_PREFIX),
+                    grantee_account.id(ACCOUNT_PREFIX).unwrap(),
                     tx_metadata.clone(),
                 )
                 .await
@@ -449,8 +449,8 @@ fn local_single_node_chain_test() {
             let mut msgs_to_send: Vec<::prost_types::Any> = Vec::new();
             msgs_to_send.push(
                 MsgSend {
-                    from_address: sender_account.id(ACCOUNT_PREFIX),
-                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX),
+                    from_address: sender_account.id(ACCOUNT_PREFIX).unwrap(),
+                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX).unwrap(),
                     amount: vec![amount.clone()],
                 }
                 .to_any()

--- a/ocular/tests/single_node_chain_txs.rs
+++ b/ocular/tests/single_node_chain_txs.rs
@@ -2,20 +2,17 @@
 
 // Requies docker
 use ocular::{
-    account::AccountInfo,
     chain::{client::cache::Cache, config::ChainClientConfig},
     cosmos_modules::*,
     keyring::Keyring,
     tx::{MultiSendIo, TxMetadata},
 };
 
-use bip32;
 use cosmos_sdk_proto::cosmos::authz::v1beta1::{
     GenericAuthorization, MsgExec, MsgGrant, MsgRevoke,
 };
 use cosmrs::{
     bank::{MsgMultiSend, MsgSend},
-    crypto::secp256k1::SigningKey,
     dev, rpc,
     tx::{self, AccountNumber, Fee, Msg, SignDoc, SignerInfo},
     Coin,
@@ -57,256 +54,12 @@ fn local_single_node_chain_test() {
     let timeout_height = 9001u16;
 
     let mut temp_ring = Keyring::new_file_store(None).expect("Could not create keyring.");
-    let sender_mnemonic = temp_ring
+    let _sender_mnemonic = temp_ring
         .create_cosmos_key("test_only_key_override_safe", "", true)
         .expect("Could not create key");
-
-    let sender_seed = sender_mnemonic.to_seed("");
-    let path = &"m/44'/118'/0'/0/0"
-        .parse::<bip32::DerivationPath>()
-        .expect("Could not parse derivation path.");
-
-    let sender_private_key: SigningKey = SigningKey::from_bytes(
-        &bip32::XPrv::derive_from_path(sender_seed, path)
-            .expect("Could not create key.")
-            .private_key()
-            .to_bytes() as &[u8],
-    )
-    .expect("Could not create key.");
-
-    let sender_public_key = sender_private_key.public_key();
-    let sender_account_id = sender_public_key
-        .account_id(ACCOUNT_PREFIX)
-        .expect("Could not create account id.");
-
-    let recipient_mnemonic = temp_ring
-        .create_cosmos_key("test_only_key_number_2_override_safe", "", true)
-        .expect("Could not create key");
-
-    let recipient_seed = recipient_mnemonic.to_seed("");
-    let path = &"m/44'/118'/0'/0/0"
-        .parse::<bip32::DerivationPath>()
-        .expect("Could not parse derivation path.");
-
-    let recipient_private_key: SigningKey = SigningKey::from_bytes(
-        &bip32::XPrv::derive_from_path(recipient_seed, path)
-            .expect("Could not create key.")
-            .private_key()
-            .to_bytes() as &[u8],
-    )
-    .expect("Could not create key.");
-
-    let recipient_public_key = recipient_private_key.public_key();
-    let recipient_account_id = recipient_public_key
-        .account_id(ACCOUNT_PREFIX)
-        .expect("Could not create account id.");
-
-    let _delegate_mnemonic = temp_ring
-        .create_cosmos_key("test_only_delegate_key_override_safe", "", true)
-        .expect("Could not create key");
-
-    let ad_hoc_private_key = temp_ring
-        .get_key("test_only_delegate_key_override_safe")
-        .expect("Could not get private key");
-    let ad_hoc_pub_info = temp_ring
-        .get_account("test_only_delegate_key_override_safe", ACCOUNT_PREFIX)
-        .expect("Could not get public key info.");
-    dbg!(ad_hoc_pub_info.id.as_ref());
-    let ad_hoc_acct = AccountInfo {
-        id: ad_hoc_pub_info.id,
-        public_key: ad_hoc_pub_info.public_key,
-        private_key: ad_hoc_private_key,
-    };
-
-    let amount = Coin {
-        amount: 1u8.into(),
-        denom: DENOM.parse().expect("Could not parse denom."),
-    };
-    let default_fee_amount = 0u32;
-    let default_fee = Coin {
-        amount: default_fee_amount.into(),
-        denom: DENOM.parse().expect("Could not parse denom"),
-    };
-    let fee = Fee::from_amount_and_gas(default_fee.clone(), gas);
-
-    // Expected MsgSend
-    let msg_send = MsgSend {
-        from_address: sender_account_id.clone(),
-        to_address: recipient_account_id.clone(),
-        amount: vec![amount.clone()],
-    }
-    .to_any()
-    .expect("Could not serlialize msg.");
-
-    let expected_tx_body = tx::Body::new(vec![msg_send], MEMO, timeout_height);
-    let expected_auth_info =
-        SignerInfo::single_direct(Some(sender_public_key), sequence_number).auth_info(fee.clone());
-    let expected_sign_doc = SignDoc::new(
-        &expected_tx_body,
-        &expected_auth_info,
-        &chain_id,
-        SENDER_ACCOUNT_NUMBER,
-    )
-    .expect("Could not parse sign doc.");
-    let _expected_tx_raw = expected_sign_doc
-        .sign(&sender_private_key)
-        .expect("Could not parse tx.");
-
-    // Expected MsgGrant
-    let msg_grant = MsgGrant {
-        granter: sender_account_id.to_string(),
-        grantee: recipient_account_id.to_string(),
-        grant: Some(authz::Grant {
-            authorization: Some(prost_types::Any {
-                type_url: String::from("/cosmos.authz.v1beta1.GenericAuthorization"),
-                value: GenericAuthorization {
-                    msg: String::from("/cosmos.bank.v1beta1.MsgSend"),
-                }
-                .encode_to_vec(),
-            }),
-            expiration: Some(prost_types::Timestamp {
-                seconds: 4110314268,
-                nanos: 0,
-            }),
-        }),
-    };
-
-    let msg_grant = prost_types::Any {
-        type_url: String::from("/cosmos.authz.v1beta1.MsgGrant"),
-        value: msg_grant.encode_to_vec(),
-    };
-
-    let expected_msg_grant_body = tx::Body::new(vec![msg_grant], MEMO, timeout_height);
-    let expected_msg_grant_auth_info =
-        SignerInfo::single_direct(Some(sender_public_key), sequence_number + 1)
-            .auth_info(fee.clone());
-    let expected_msg_grant_sign_doc = SignDoc::new(
-        &expected_msg_grant_body,
-        &expected_msg_grant_auth_info,
-        &chain_id,
-        SENDER_ACCOUNT_NUMBER,
-    )
-    .expect("Could not parse sign doc.");
-    let _expected_msg_grant_raw = expected_msg_grant_sign_doc.sign(&sender_private_key);
-
-    // Expected MsgRevoke
-    let msg_revoke = MsgRevoke {
-        granter: sender_account_id.to_string(),
-        grantee: recipient_account_id.to_string(),
-        msg_type_url: String::from("/cosmos.bank.v1beta1.MsgSend"),
-    };
-
-    let msg_revoke = prost_types::Any {
-        type_url: String::from("/cosmos.authz.v1beta1.MsgRevoke"),
-        value: msg_revoke.encode_to_vec(),
-    };
-
-    let expected_msg_revoke_body = tx::Body::new(vec![msg_revoke], MEMO, timeout_height);
-    let expected_msg_revoke_auth_info =
-        SignerInfo::single_direct(Some(sender_public_key), sequence_number + 2)
-            .auth_info(fee.clone());
-    let expected_msg_revoke_sign_doc = SignDoc::new(
-        &expected_msg_revoke_body,
-        &expected_msg_revoke_auth_info,
-        &chain_id,
-        SENDER_ACCOUNT_NUMBER,
-    )
-    .expect("Could not parse sign doc.");
-    let _expected_msg_revoke_raw = expected_msg_revoke_sign_doc.sign(&sender_private_key);
-
-    // Expected MsgExec
-    let mut msgs_to_execute: Vec<::prost_types::Any> = Vec::new();
-    msgs_to_execute.push(
-        MsgSend {
-            from_address: sender_account_id.clone(),
-            to_address: ad_hoc_acct.id.clone(),
-            amount: vec![amount.clone()],
-        }
-        .to_any()
-        .expect("Could not serlialize msg."),
-    );
-
-    let msg_exec = MsgExec {
-        grantee: recipient_account_id.to_string(),
-        msgs: msgs_to_execute,
-    };
-
-    let msg_exec = prost_types::Any {
-        type_url: String::from("/cosmos.authz.v1beta1.MsgExec"),
-        value: msg_exec.encode_to_vec(),
-    };
-
-    let expected_msg_exec_body = tx::Body::new(vec![msg_exec], MEMO, timeout_height);
-    let expected_msg_exec_auth_info =
-        SignerInfo::single_direct(Some(recipient_public_key), sequence_number)
-            .auth_info(fee.clone());
-    let expected_msg_exec_sign_doc = SignDoc::new(
-        &expected_msg_exec_body,
-        &expected_msg_exec_auth_info,
-        &chain_id,
-        RECIPIENT_ACCOUNT_NUMBER,
-    )
-    .expect("Could not parse sign doc.");
-    let _expected_msg_exec_raw = expected_msg_exec_sign_doc.sign(&sender_private_key);
-
-    // expected MsgMultiSend
-    let input_a = MultiSendIo {
-        address: sender_account_id.as_ref().to_string(),
-        coins: vec![ocular::tx::Coin {
-            amount: 50,
-            denom: DENOM.to_string(),
-        }],
-    };
-    let input_b = MultiSendIo {
-        address: sender_account_id.as_ref().to_string(),
-        coins: vec![ocular::tx::Coin {
-            amount: 100,
-            denom: DENOM.to_string(),
-        }],
-    };
-    let output_a = MultiSendIo {
-        address: ad_hoc_acct.id.as_ref().to_string(),
-        coins: vec![ocular::tx::Coin {
-            amount: 75,
-            denom: DENOM.to_string(),
-        }],
-    };
-    let output_b = MultiSendIo {
-        address: recipient_account_id.as_ref().to_string(),
-        coins: vec![ocular::tx::Coin {
-            amount: 75,
-            denom: DENOM.to_string(),
-        }],
-    };
-    let inputs = vec![input_a.clone(), input_b.clone()];
-    let outputs = vec![output_a.clone(), output_b.clone()];
-
-    let msg_inputs: Vec<cosmrs::bank::MultiSendIo> = vec![
-        input_a
-            .try_into()
-            .expect("couldn't convert multi send input value"),
-        input_b
-            .try_into()
-            .expect("couldn't convert multi send input value"),
-    ];
-    let msg_outputs: Vec<cosmrs::bank::MultiSendIo> = vec![
-        output_a
-            .try_into()
-            .expect("couldn't convert multi send output value"),
-        output_b
-            .try_into()
-            .expect("couldn't convert multi send output value"),
-    ];
-    let msg_multi_send = MsgMultiSend {
-        inputs: msg_inputs,
-        outputs: msg_outputs,
-    }
-    .to_any()
-    .expect("could not serialize multi send msg");
-    let expected_multisend_tx_body = tx::Body::new(vec![msg_multi_send], MEMO, timeout_height);
-    let expected_multisend_auth_info =
-        SignerInfo::single_direct(Some(sender_public_key), sequence_number + 3)
-            .auth_info(fee.clone());
+    let sender_account = temp_ring
+        .get_account("test_only_key_override_safe")
+        .expect("Couldn't retrieve AccountInfo");
 
     let docker_args = [
         "-d",
@@ -316,11 +69,219 @@ fn local_single_node_chain_test() {
         &format!("{}:{}", 9090, 9090),
         DOCKER_HUB_GAIA_SINGLE_NODE_TEST_IMAGE,
         CHAIN_ID,
-        &sender_account_id.to_string(),
+        &sender_account.address(ACCOUNT_PREFIX),
     ];
 
     dev::docker_run(&docker_args, || {
         init_tokio_runtime().block_on(async {
+            let mut temp_ring = Keyring::new_file_store(None).expect("Could not create keyring.");
+            let sender_account = temp_ring
+                .get_account("test_only_key_override_safe")
+                .expect("Couldn't retrieve AccountInfo");
+            let _recipient_mnemonic = temp_ring
+                .create_cosmos_key("test_only_key_number_2_override_safe", "", true)
+                .expect("Could not create key");
+            let recipient_account = temp_ring
+                .get_account("test_only_key_number_2_override_safe")
+                .expect("Couldn't retrieve AccountInfo");
+
+            let _delegate_mnemonic = temp_ring
+                .create_cosmos_key("test_only_delegate_key_override_safe", "", true)
+                .expect("Could not create key");
+            let ad_hoc_account = temp_ring
+                .get_account("test_only_delegate_key_override_safe")
+                .expect("Could not get public key info.");
+
+            let amount = Coin {
+                amount: 1u8.into(),
+                denom: DENOM.parse().expect("Could not parse denom."),
+            };
+            let default_fee_amount = 0u32;
+            let default_fee = Coin {
+                amount: default_fee_amount.into(),
+                denom: DENOM.parse().expect("Could not parse denom"),
+            };
+            let fee = Fee::from_amount_and_gas(default_fee.clone(), gas);
+
+            // Expected MsgSend
+            let msg_send = MsgSend {
+                from_address: sender_account.id(ACCOUNT_PREFIX),
+                to_address: recipient_account.id(ACCOUNT_PREFIX),
+                amount: vec![amount.clone()],
+            }
+            .to_any()
+            .expect("Could not serlialize msg.");
+
+            let expected_tx_body = tx::Body::new(vec![msg_send], MEMO, timeout_height);
+            let expected_auth_info =
+                SignerInfo::single_direct(Some(sender_account.public_key()), sequence_number).auth_info(fee.clone());
+            let expected_sign_doc = SignDoc::new(
+                &expected_tx_body,
+                &expected_auth_info,
+                &chain_id,
+                SENDER_ACCOUNT_NUMBER,
+            )
+            .expect("Could not parse sign doc.");
+            let _expected_tx_raw = expected_sign_doc
+                .sign(sender_account.private_key())
+                .expect("Could not parse tx.");
+
+            // Expected MsgGrant
+            let msg_grant = MsgGrant {
+                granter: sender_account.address(ACCOUNT_PREFIX),
+                grantee: recipient_account.address(ACCOUNT_PREFIX),
+                grant: Some(authz::Grant {
+                    authorization: Some(prost_types::Any {
+                        type_url: String::from("/cosmos.authz.v1beta1.GenericAuthorization"),
+                        value: GenericAuthorization {
+                            msg: String::from("/cosmos.bank.v1beta1.MsgSend"),
+                        }
+                        .encode_to_vec(),
+                    }),
+                    expiration: Some(prost_types::Timestamp {
+                        seconds: 4110314268,
+                        nanos: 0,
+                    }),
+                }),
+            };
+
+            let msg_grant = prost_types::Any {
+                type_url: String::from("/cosmos.authz.v1beta1.MsgGrant"),
+                value: msg_grant.encode_to_vec(),
+            };
+
+            let expected_msg_grant_body = tx::Body::new(vec![msg_grant], MEMO, timeout_height);
+            let expected_msg_grant_auth_info =
+                SignerInfo::single_direct(Some(sender_account.public_key()), sequence_number + 1)
+                    .auth_info(fee.clone());
+            let expected_msg_grant_sign_doc = SignDoc::new(
+                &expected_msg_grant_body,
+                &expected_msg_grant_auth_info,
+                &chain_id,
+                SENDER_ACCOUNT_NUMBER,
+            )
+            .expect("Could not parse sign doc.");
+            let _expected_msg_grant_raw = expected_msg_grant_sign_doc.sign(sender_account.private_key());
+
+            // Expected MsgRevoke
+            let msg_revoke = MsgRevoke {
+                granter: sender_account.address(ACCOUNT_PREFIX),
+                grantee: recipient_account.address(ACCOUNT_PREFIX),
+                msg_type_url: String::from("/cosmos.bank.v1beta1.MsgSend"),
+            };
+
+            let msg_revoke = prost_types::Any {
+                type_url: String::from("/cosmos.authz.v1beta1.MsgRevoke"),
+                value: msg_revoke.encode_to_vec(),
+            };
+
+            let expected_msg_revoke_body = tx::Body::new(vec![msg_revoke], MEMO, timeout_height);
+            let expected_msg_revoke_auth_info =
+                SignerInfo::single_direct(Some(sender_account.public_key()), sequence_number + 2)
+                    .auth_info(fee.clone());
+            let expected_msg_revoke_sign_doc = SignDoc::new(
+                &expected_msg_revoke_body,
+                &expected_msg_revoke_auth_info,
+                &chain_id,
+                SENDER_ACCOUNT_NUMBER,
+            )
+            .expect("Could not parse sign doc.");
+            let _expected_msg_revoke_raw = expected_msg_revoke_sign_doc.sign(sender_account.private_key());
+
+            // Expected MsgExec
+            let mut msgs_to_execute: Vec<::prost_types::Any> = Vec::new();
+            msgs_to_execute.push(
+                MsgSend {
+                    from_address: sender_account.id(ACCOUNT_PREFIX),
+                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX),
+                    amount: vec![amount.clone()],
+                }
+                .to_any()
+                .expect("Could not serlialize msg."),
+            );
+
+            let msg_exec = MsgExec {
+                grantee: recipient_account.address(ACCOUNT_PREFIX),
+                msgs: msgs_to_execute,
+            };
+
+            let msg_exec = prost_types::Any {
+                type_url: String::from("/cosmos.authz.v1beta1.MsgExec"),
+                value: msg_exec.encode_to_vec(),
+            };
+
+            let expected_msg_exec_body = tx::Body::new(vec![msg_exec], MEMO, timeout_height);
+            let expected_msg_exec_auth_info =
+                SignerInfo::single_direct(Some(recipient_account.public_key()), sequence_number)
+                    .auth_info(fee.clone());
+            let expected_msg_exec_sign_doc = SignDoc::new(
+                &expected_msg_exec_body,
+                &expected_msg_exec_auth_info,
+                &chain_id,
+                RECIPIENT_ACCOUNT_NUMBER,
+            )
+            .expect("Could not parse sign doc.");
+            let _expected_msg_exec_raw = expected_msg_exec_sign_doc.sign(sender_account.private_key());
+
+            // expected MsgMultiSend
+            let input_a = MultiSendIo {
+                address: sender_account.address(ACCOUNT_PREFIX),
+                coins: vec![ocular::tx::Coin {
+                    amount: 50,
+                    denom: DENOM.to_string(),
+                }],
+            };
+            let input_b = MultiSendIo {
+                address: sender_account.address(ACCOUNT_PREFIX),
+                coins: vec![ocular::tx::Coin {
+                    amount: 100,
+                    denom: DENOM.to_string(),
+                }],
+            };
+            let output_a = MultiSendIo {
+                address: ad_hoc_account.address(ACCOUNT_PREFIX),
+                coins: vec![ocular::tx::Coin {
+                    amount: 75,
+                    denom: DENOM.to_string(),
+                }],
+            };
+            let output_b = MultiSendIo {
+                address: recipient_account.address(ACCOUNT_PREFIX),
+                coins: vec![ocular::tx::Coin {
+                    amount: 75,
+                    denom: DENOM.to_string(),
+                }],
+            };
+            let inputs = vec![input_a.clone(), input_b.clone()];
+            let outputs = vec![output_a.clone(), output_b.clone()];
+
+            let msg_inputs: Vec<cosmrs::bank::MultiSendIo> = vec![
+                input_a
+                    .try_into()
+                    .expect("couldn't convert multi send input value"),
+                input_b
+                    .try_into()
+                    .expect("couldn't convert multi send input value"),
+            ];
+            let msg_outputs: Vec<cosmrs::bank::MultiSendIo> = vec![
+                output_a
+                    .try_into()
+                    .expect("couldn't convert multi send output value"),
+                output_b
+                    .try_into()
+                    .expect("couldn't convert multi send output value"),
+            ];
+            let msg_multi_send = MsgMultiSend {
+                inputs: msg_inputs,
+                outputs: msg_outputs,
+            }
+            .to_any()
+            .expect("could not serialize multi send msg");
+            let expected_multisend_tx_body = tx::Body::new(vec![msg_multi_send], MEMO, timeout_height);
+            let expected_multisend_auth_info =
+                SignerInfo::single_direct(Some(sender_account.public_key()), sequence_number + 3)
+                    .auth_info(fee.clone());
+
             let rpc_address = format!("http://localhost:{}", RPC_PORT);
             let rpc_client =
             rpc::HttpClient::new(rpc_address.as_str()).expect("Could not create RPC");
@@ -354,24 +315,11 @@ fn local_single_node_chain_test() {
                 memo: MEMO.to_string(),
             };
 
-            let sender_seed = sender_mnemonic.to_seed("");
-            let sender_private_key: SigningKey = SigningKey::from_bytes(
-                &bip32::XPrv::derive_from_path(sender_seed, path)
-                    .expect("Could not create key.")
-                    .private_key()
-                    .to_bytes() as &[u8],
-            )
-            .expect("Could not create key.");
-
             // Test MsgSend functionality
             let actual_tx_commit_response = chain_client
                 .send(
-                    AccountInfo {
-                        id: sender_account_id.clone(),
-                        public_key: sender_public_key,
-                        private_key: sender_private_key,
-                    },
-                    recipient_account_id.clone().as_ref(),
+                    sender_account.clone(),
+                    recipient_account.id(ACCOUNT_PREFIX).as_ref(),
                     amount.clone(),
                     Some(tx_metadata.clone()),
                 )
@@ -390,23 +338,10 @@ fn local_single_node_chain_test() {
             assert_eq!(&expected_auth_info, &actual_tx.auth_info);
 
             // Test MsgGrant functionality
-            let sender_seed = sender_mnemonic.to_seed("");
-            let sender_private_key: SigningKey = SigningKey::from_bytes(
-                &bip32::XPrv::derive_from_path(sender_seed, path)
-                    .expect("Could not create key.")
-                    .private_key()
-                    .to_bytes() as &[u8],
-            )
-            .expect("Could not create key.");
-
             let actual_msg_grant_commit_response = chain_client
                 .grant_send_authorization(
-                    AccountInfo {
-                        id: sender_account_id.clone(),
-                        public_key: sender_public_key,
-                        private_key: sender_private_key,
-                    },
-                    recipient_account_id.clone(),
+                    sender_account.clone(),
+                    recipient_account.id(ACCOUNT_PREFIX),
                     Some(prost_types::Timestamp {
                         seconds: 4110314268,
                         nanos: 0,
@@ -436,20 +371,13 @@ fn local_single_node_chain_test() {
             assert_eq!(&expected_msg_grant_auth_info, &actual_msg_grant.auth_info);
 
             // Test MsgExec functionality
-            let grantee_seed = recipient_mnemonic.to_seed("");
-            let grantee_private_key: SigningKey = SigningKey::from_bytes(
-                &bip32::XPrv::derive_from_path(grantee_seed, path)
-                    .expect("Could not create key.")
-                    .private_key()
-                    .to_bytes() as &[u8],
-            )
-            .expect("Could not create key.");
+            let grantee_account = recipient_account;
 
             let mut msgs_to_send: Vec<::prost_types::Any> = Vec::new();
             msgs_to_send.push(
                 MsgSend {
-                    from_address: sender_account_id.clone(),
-                    to_address: ad_hoc_acct.id.clone(),
+                    from_address: sender_account.id(ACCOUNT_PREFIX),
+                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX),
                     amount: vec![amount.clone()],
                 }
                 .to_any()
@@ -458,11 +386,7 @@ fn local_single_node_chain_test() {
 
             let actual_msg_exec_commit_response = chain_client
                 .execute_authorized_tx(
-                    AccountInfo {
-                        id: recipient_account_id.clone(),
-                        public_key: grantee_private_key.public_key(),
-                        private_key: grantee_private_key,
-                    },
+                    grantee_account.clone(),
                     msgs_to_send,
                     Some(tx_metadata.clone()),
                 )
@@ -490,23 +414,10 @@ fn local_single_node_chain_test() {
             assert_eq!(&expected_msg_exec_auth_info, &actual_msg_exec.auth_info);
 
             // Test MsgRevoke functionality
-            let sender_seed = sender_mnemonic.to_seed("");
-            let sender_private_key: SigningKey = SigningKey::from_bytes(
-                &bip32::XPrv::derive_from_path(sender_seed, path)
-                    .expect("Could not create key.")
-                    .private_key()
-                    .to_bytes() as &[u8],
-            )
-            .expect("Could not create key.");
-
             let actual_msg_revoke_commit_response = chain_client
                 .revoke_send_authorization(
-                    AccountInfo {
-                        id: sender_account_id.clone(),
-                        public_key: sender_public_key,
-                        private_key: sender_private_key,
-                    },
-                    recipient_account_id.clone(),
+                    sender_account.clone(),
+                    grantee_account.id(ACCOUNT_PREFIX),
                     tx_metadata.clone(),
                 )
                 .await
@@ -532,23 +443,14 @@ fn local_single_node_chain_test() {
             assert_eq!(&expected_msg_revoke_auth_info, &actual_msg_revoke.auth_info);
 
             // Test MsgExec does not work after permissions revoked
-            let grantee_seed = recipient_mnemonic.to_seed("");
-            let grantee_private_key: SigningKey = SigningKey::from_bytes(
-                &bip32::XPrv::derive_from_path(grantee_seed, path)
-                    .expect("Could not create key.")
-                    .private_key()
-                    .to_bytes() as &[u8],
-            )
-            .expect("Could not create key.");
-
             let mut tx_metadata_memoed = tx_metadata.clone();
             tx_metadata_memoed.memo = String::from("Exec tx #2");
 
             let mut msgs_to_send: Vec<::prost_types::Any> = Vec::new();
             msgs_to_send.push(
                 MsgSend {
-                    from_address: sender_account_id.clone(),
-                    to_address: ad_hoc_acct.id.clone(),
+                    from_address: sender_account.id(ACCOUNT_PREFIX),
+                    to_address: ad_hoc_account.id(ACCOUNT_PREFIX),
                     amount: vec![amount.clone()],
                 }
                 .to_any()
@@ -557,11 +459,7 @@ fn local_single_node_chain_test() {
 
             let actual_msg_exec_commit_response = chain_client
                 .execute_authorized_tx(
-                    AccountInfo {
-                        id: recipient_account_id.clone(),
-                        public_key: grantee_private_key.public_key(),
-                        private_key: grantee_private_key,
-                    },
+                    grantee_account.clone(),
                     msgs_to_send,
                     Some(tx_metadata_memoed),
                 )
@@ -579,21 +477,9 @@ fn local_single_node_chain_test() {
             assert_eq!(&actual_msg_exec_commit_response.deliver_tx.log.to_string()[..82], "failed to execute message; message index: 0: authorization not found: unauthorized");
 
             // Test MsgMultiSend functionality
-            let sender_seed = sender_mnemonic.to_seed("");
-            let sender_private_key: SigningKey = SigningKey::from_bytes(
-                &bip32::XPrv::derive_from_path(sender_seed, path)
-                    .expect("Could not create key.")
-                    .private_key()
-                    .to_bytes() as &[u8],
-            )
-            .expect("Could not create key.");
             let actual_tx_commit_response = chain_client
                 .multi_send(
-                    AccountInfo {
-                        id: sender_account_id.clone(),
-                        public_key: sender_public_key,
-                        private_key: sender_private_key,
-                    },
+                    sender_account.clone(),
                     inputs,
                     outputs,
                     Some(tx_metadata),


### PR DESCRIPTION
- Hides `AccountInfo` fields behind methods
- Decouples `AccountInfo` from a specific prefix. `address()` and `id()` will derive the respective values on demand given a prefix `&str`.
- Puts an `AccountInfo`'s private key behind an `Arc<T>` so that it can be `Clone`. This makes the type much more ergonomic.
- Adds `TryFrom<SigningKey>` and `TryFrom<Arc<SigningKey>>` impl constructors for `AccountInfo`. Importantly, it checks that an `AccountId` can be derived from the associated public key and returns an error otherwise. This allows us to assert that the `AccountId` derivations will not error and therefore don't need to return a `Result`. **EDIT: changed to `From<T>`**

## Example

```rust
// Get an account's address from a key in a keystore
let account = keystore.get_account("my_account")?;
let address = account.address("cosmos")?;
```

```rust
// Create a new private key and derive the account
let sender_mnemonic = keyring
    .create_cosmos_key("my_new_account", "", true)
    .unwrap();
let seed = mnemonic.to_seed("");
let private_key: SigningKey = SigningKey::from_bytes(
    &bip32::XPrv::derive_from_path(seed, path)
        .expect("Could not create key.")
        .private_key()
        .to_bytes() as &[u8],
)
.unwrap();
let account = AccountInfo::from(private_key);
```

EDIT: examples after updates